### PR TITLE
Upgrade aws s3 sdk version and exclude jackson dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,8 +50,10 @@ defaultTasks 'clean', 'jar'
 dependencies {
 
     compile 'org.apache.commons:commons-vfs2:2.1.1744488.1'
-    compile("com.amazonaws:aws-java-sdk-s3:1.11.22"){
+    compile("com.amazonaws:aws-java-sdk-s3:1.11.297"){
         exclude module: "httpcore"
+        exclude group: "com.fasterxml.jackson.core"
+        exclude group: "com.fasterxml.jackson.dataformat"
     }
     compile 'org.springframework:spring-beans:4.2.5.RELEASE'
     testCompile 'org.testng:testng:6.9.10'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-projectVersion=2.4.7
+projectVersion=2.4.8


### PR DESCRIPTION
  - Jackson libraries are embedded in the vfs-s3 jar, which creates issues with other projects using jackson.